### PR TITLE
Feature/add proxy commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## [Unreleased](https://github.com/markwalet/laravel-changelog/compare/v1.1.0...master)
 
 ### Added
-- Added alias command `changelog:added {message}` to quickly add a new added entry 
+- Added alias command `changelog:added {message}` to quickly add a new added entry
+- Added alias command `changelog:changed {message}` to quickly add a new changed entry
+- Added alias command `changelog:deprecated {message}` to quickly add a new deprecated entry
+- Added alias command `changelog:removed {message}` to quickly add a new removed entry
+- Added alias command `changelog:fixed {message}` to quickly add a new fixed entry
+- Added alias command `changelog:security {message}` to quickly add a new security entry
 
 ## [v1.1.1 (2019-10-17)](https://github.com/markwalet/laravel-changelog/compare/v1.1.0...v1.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/markwalet/laravel-changelog/compare/v1.1.0...master)
 
+### Added
+- Added alias command `changelog:added {message}` to quickly add a new added entry 
+
 ## [v1.1.1 (2019-10-17)](https://github.com/markwalet/laravel-changelog/compare/v1.1.0...v1.1.1)
 
 ### Fixed

--- a/src/ChangelogServiceProvider.php
+++ b/src/ChangelogServiceProvider.php
@@ -9,9 +9,15 @@ use MarkWalet\Changelog\Adapters\ReleaseAdapter;
 use MarkWalet\Changelog\Adapters\XmlFeatureAdapter;
 use MarkWalet\Changelog\Adapters\XmlReleaseAdapter;
 use MarkWalet\Changelog\Commands\ChangelogAddCommand;
+use MarkWalet\Changelog\Commands\ChangelogAddedCommand;
+use MarkWalet\Changelog\Commands\ChangelogChangedCommand;
+use MarkWalet\Changelog\Commands\ChangelogDeprecatedCommand;
+use MarkWalet\Changelog\Commands\ChangelogFixedCommand;
 use MarkWalet\Changelog\Commands\ChangelogGenerateCommand;
 use MarkWalet\Changelog\Commands\ChangelogListCommand;
 use MarkWalet\Changelog\Commands\ChangelogReleaseCommand;
+use MarkWalet\Changelog\Commands\ChangelogRemovedCommand;
+use MarkWalet\Changelog\Commands\ChangelogSecurityCommand;
 use MarkWalet\Changelog\Commands\ChangelogUnreleasedCommand;
 
 class ChangelogServiceProvider extends ServiceProvider
@@ -74,6 +80,15 @@ class ChangelogServiceProvider extends ServiceProvider
                 ChangelogUnreleasedCommand::class,
                 ChangelogReleaseCommand::class,
                 ChangelogGenerateCommand::class,
+
+                //aliases
+                ChangelogAddedCommand::class,
+                ChangelogChangedCommand::class,
+                ChangelogDeprecatedCommand::class,
+                ChangelogRemovedCommand::class,
+                ChangelogFixedCommand::class,
+                ChangelogSecurityCommand::class,
+
             ]);
         }
     }

--- a/src/Commands/ChangelogAddedCommand.php
+++ b/src/Commands/ChangelogAddedCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MarkWalet\Changelog\Commands;
+
+use Illuminate\Console\Command;
+
+class ChangelogAddedCommand extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'changelog:added {message}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a added change to the current feature entry';
+
+    /**
+     * Execute the command.
+     */
+    public function handle()
+    {
+        $this->call('changelog:add',
+                    [
+                        '--type' => 'added',
+                        '--message' => $this->argument('message')
+                    ]
+        );
+    }
+}

--- a/src/Commands/ChangelogAddedCommand.php
+++ b/src/Commands/ChangelogAddedCommand.php
@@ -3,9 +3,11 @@
 namespace MarkWalet\Changelog\Commands;
 
 use Illuminate\Console\Command;
+use MarkWalet\Changelog\Concerns\CallsAddCommand;
 
 class ChangelogAddedCommand extends Command
 {
+    use CallsAddCommand;
 
     /**
      * The name and signature of the console command.
@@ -26,11 +28,6 @@ class ChangelogAddedCommand extends Command
      */
     public function handle()
     {
-        $this->call('changelog:add',
-                    [
-                        '--type' => 'added',
-                        '--message' => $this->argument('message')
-                    ]
-        );
+        $this->callAdd('added', $this->argument('message'));
     }
 }

--- a/src/Commands/ChangelogChangedCommand.php
+++ b/src/Commands/ChangelogChangedCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MarkWalet\Changelog\Commands;
+
+use Illuminate\Console\Command;
+use MarkWalet\Changelog\Concerns\CallsAddCommand;
+
+class ChangelogChangedCommand extends Command
+{
+    use CallsAddCommand;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'changelog:changed {message}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a changed change to the current feature entry';
+
+    /**
+     * Execute the command.
+     */
+    public function handle()
+    {
+        $this->callAdd('changed', $this->argument('message'));
+    }
+}

--- a/src/Commands/ChangelogDeprecatedCommand.php
+++ b/src/Commands/ChangelogDeprecatedCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MarkWalet\Changelog\Commands;
+
+use Illuminate\Console\Command;
+use MarkWalet\Changelog\Concerns\CallsAddCommand;
+
+class ChangelogDeprecatedCommand extends Command
+{
+    use CallsAddCommand;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'changelog:deprecated {message}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a deprecated change to the current feature entry';
+
+    /**
+     * Execute the command.
+     */
+    public function handle()
+    {
+        $this->callAdd('deprecated', $this->argument('message'));
+    }
+}

--- a/src/Commands/ChangelogFixedCommand.php
+++ b/src/Commands/ChangelogFixedCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MarkWalet\Changelog\Commands;
+
+use Illuminate\Console\Command;
+use MarkWalet\Changelog\Concerns\CallsAddCommand;
+
+class ChangelogFixedCommand extends Command
+{
+    use CallsAddCommand;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'changelog:fixed {message}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a fixed change to the current feature entry';
+
+    /**
+     * Execute the command.
+     */
+    public function handle()
+    {
+        $this->callAdd('fixed', $this->argument('message'));
+    }
+}

--- a/src/Commands/ChangelogRemovedCommand.php
+++ b/src/Commands/ChangelogRemovedCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MarkWalet\Changelog\Commands;
+
+use Illuminate\Console\Command;
+use MarkWalet\Changelog\Concerns\CallsAddCommand;
+
+class ChangelogRemovedCommand extends Command
+{
+    use CallsAddCommand;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'changelog:removed {message}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a removed change to the current feature entry';
+
+    /**
+     * Execute the command.
+     */
+    public function handle()
+    {
+        $this->callAdd('removed', $this->argument('message'));
+    }
+}

--- a/src/Commands/ChangelogSecurityCommand.php
+++ b/src/Commands/ChangelogSecurityCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MarkWalet\Changelog\Commands;
+
+use Illuminate\Console\Command;
+use MarkWalet\Changelog\Concerns\CallsAddCommand;
+
+class ChangelogSecurityCommand extends Command
+{
+    use CallsAddCommand;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'changelog:security {message}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a security change to the current feature entry';
+
+    /**
+     * Execute the command.
+     */
+    public function handle()
+    {
+        $this->callAdd('security', $this->argument('message'));
+    }
+}

--- a/src/Concerns/CallsAddCommand.php
+++ b/src/Concerns/CallsAddCommand.php
@@ -11,7 +11,7 @@ trait CallsAddCommand
         Artisan::call('changelog:add',
                     [
                         '--type' => $type,
-                        '--message' => $message
+                        '--message' => $message,
                     ]
         );
     }

--- a/src/Concerns/CallsAddCommand.php
+++ b/src/Concerns/CallsAddCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MarkWalet\Changelog\Concerns;
+
+use Illuminate\Support\Facades\Artisan;
+
+trait CallsAddCommand
+{
+    protected function callAdd($type, $message)
+    {
+        Artisan::call('changelog:add',
+                    [
+                        '--type' => $type,
+                        '--message' => $message
+                    ]
+        );
+    }
+}

--- a/tests/Commands/ChangelogAddedCommandTest.php
+++ b/tests/Commands/ChangelogAddedCommandTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace MarkWalet\Changelog\Tests\Commands;
-
 
 use MarkWalet\Changelog\Adapters\FakeFeatureAdapter;
 use MarkWalet\Changelog\Adapters\FeatureAdapter;
@@ -11,7 +9,7 @@ use MarkWalet\GitState\Drivers\FakeGitDriver;
 use MarkWalet\GitState\Drivers\GitDriver;
 
 /**
- * Class ChangelogAddedCommandTest
+ * Class ChangelogAddedCommandTest.
  */
 class ChangelogAddedCommandTest extends LaravelTestCase
 {
@@ -52,7 +50,8 @@ class ChangelogAddedCommandTest extends LaravelTestCase
      *
      * @param string $alias
      */
-    public function the_alias_commands_work(string $alias){
+    public function the_alias_commands_work(string $alias)
+    {
         $this->app['config']['changelog.path'] = 'test-path';
         $adapter = $this->fakeAdapter();
         $this->fakeBranch('test-branch');

--- a/tests/Commands/ChangelogAddedCommandTest.php
+++ b/tests/Commands/ChangelogAddedCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace MarkWalet\Changelog\Tests\Commands;
+
+
+use MarkWalet\Changelog\Adapters\FakeFeatureAdapter;
+use MarkWalet\Changelog\Adapters\FeatureAdapter;
+use MarkWalet\Changelog\Tests\LaravelTestCase;
+use MarkWalet\GitState\Drivers\FakeGitDriver;
+use MarkWalet\GitState\Drivers\GitDriver;
+
+/**
+ * Class ChangelogAddedCommandTest
+ */
+class ChangelogAddedCommandTest extends LaravelTestCase
+{
+    /**
+     * Get and bind a fake adapter.
+     *
+     * @return FakeFeatureAdapter
+     */
+    private function fakeAdapter()
+    {
+        $adapter = new FakeFeatureAdapter;
+        $this->app->singleton(FeatureAdapter::class, function () use ($adapter) {
+            return $adapter;
+        });
+
+        return $adapter;
+    }
+
+    /**
+     * Create a fake git driver with the given branch.
+     *
+     * @param string $branch
+     * @return FakeGitDriver
+     */
+    private function fakeBranch(string $branch): FakeGitDriver
+    {
+        $driver = new FakeGitDriver(['branch' => $branch]);
+        $this->app->bind(GitDriver::class, function () use ($driver) {
+            return $driver;
+        });
+
+        return $driver;
+    }
+
+    /**
+     * @dataProvider aliases
+     * @test
+     *
+     * @param string $alias
+     */
+    public function the_alias_commands_work(string $alias){
+        $this->app['config']['changelog.path'] = 'test-path';
+        $adapter = $this->fakeAdapter();
+        $this->fakeBranch('test-branch');
+
+        $this->artisan("changelog:{$alias}", ['message' => 'this is a message']);
+        $feature = $adapter->read('test-path/unreleased/test-branch.xml');
+
+        $this->assertCount(1, $feature->changes());
+        $this->assertEquals($alias, $feature->changes()[0]->type());
+        $this->assertEquals('this is a message', $feature->changes()[0]->message());
+    }
+
+    public function aliases()
+    {
+        return [['added'], ['changed'], ['deprecated'], ['removed'], ['fixed'], ['security']];
+    }
+}


### PR DESCRIPTION
This MR adds 6 new commands that are simple aliases to the [keep a changelog](https://keepachangelog.com/en/1.0.0/#how) changelog standard entries.

## Added
- Added alias command `changelog:added {message}` to quickly add a new added entry
- Added alias command `changelog:changed {message}` to quickly add a new changed entry
- Added alias command `changelog:deprecated {message}` to quickly add a new deprecated entry
- Added alias command `changelog:removed {message}` to quickly add a new removed entry
- Added alias command `changelog:fixed {message}` to quickly add a new fixed entry
- Added alias command `changelog:security {message}` to quickly add a new security entry

