### PR TITLE
Handle invalid XML in changelog commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Re-enable the fake release adapter test coverage for release execution.
 - Fix type annotations and formatting issues required by the new static analysis checks.
 
+### Fixed
+- Catch invalid XML parsing errors in commands and show a warning instead of throwing an exception.
+
 ### Removed
 - Removed support for Laravel 10.
 - Removed support for Laravel 11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,7 @@
 - Make release moves deterministic and restore the unreleased `.gitkeep` placeholder.
 - Re-enable the fake release adapter test coverage for release execution.
 - Fix type annotations and formatting issues required by the new static analysis checks.
-
-### Fixed
-- Catch invalid XML parsing errors in commands and show a warning instead of throwing an exception.
+- Catch invalid XML parsing errors in commands and show a warning instead of throwing an exception ([#18](https://github.com/markwalet/laravel-changelog/issues/18)).
 
 ### Removed
 - Removed support for Laravel 10.

--- a/src/Adapters/XmlFeatureAdapter.php
+++ b/src/Adapters/XmlFeatureAdapter.php
@@ -39,14 +39,33 @@ class XmlFeatureAdapter implements FeatureAdapter
             throw new FileNotFoundException($path);
         }
 
+        $previousValue = libxml_use_internal_errors(true);
         $element = simplexml_load_string($content);
+        if ($element === false) {
+            $error = collect(libxml_get_errors())
+                ->map(fn (\LibXMLError $error) => trim($error->message))
+                ->filter()
+                ->implode(', ');
+
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousValue);
+
+            $message = "Invalid xml in \"$path\".";
+            if ($error !== '') {
+                $message = "Invalid xml in \"$path\": $error";
+            }
+
+            throw new InvalidXmlException($message);
+        }
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousValue);
 
         $feature = new Feature;
 
         foreach ($element->children() as $change) {
             $type = $change->attributes()['type'];
             if (is_null($type)) {
-                throw new InvalidXmlException('Missing `type` attribute on change element.');
+                throw new InvalidXmlException("Invalid xml in \"$path\": Missing `type` attribute on change element.");
             }
             $message = (string) $change;
 

--- a/src/Adapters/XmlFeatureAdapter.php
+++ b/src/Adapters/XmlFeatureAdapter.php
@@ -5,6 +5,7 @@ namespace MarkWalet\Changelog\Adapters;
 use DOMDocument;
 use Illuminate\Contracts\Filesystem\FileNotFoundException as FilesystemFileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
+use LibXMLError;
 use MarkWalet\Changelog\Change;
 use MarkWalet\Changelog\Exceptions\FileNotFoundException;
 use MarkWalet\Changelog\Exceptions\InvalidXmlException;
@@ -43,7 +44,7 @@ class XmlFeatureAdapter implements FeatureAdapter
         $element = simplexml_load_string($content);
         if ($element === false) {
             $error = collect(libxml_get_errors())
-                ->map(fn (\LibXMLError $error) => trim($error->message))
+                ->map(fn (LibXMLError $error) => trim($error->message))
                 ->filter()
                 ->implode(', ');
 

--- a/src/Commands/ChangelogAddCommand.php
+++ b/src/Commands/ChangelogAddCommand.php
@@ -5,11 +5,15 @@ namespace MarkWalet\Changelog\Commands;
 use Illuminate\Console\Command;
 use MarkWalet\Changelog\Adapters\FeatureAdapter;
 use MarkWalet\Changelog\Change;
+use MarkWalet\Changelog\Commands\Concerns\WarnsAboutInvalidXml;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Feature;
 use MarkWalet\GitState\Drivers\GitDriver;
 
 class ChangelogAddCommand extends Command
 {
+    use WarnsAboutInvalidXml;
+
     /**
      * The name and signature of the console command.
      *
@@ -34,7 +38,11 @@ class ChangelogAddCommand extends Command
     {
         $path = $this->path($gitState);
 
-        $feature = $this->changelog($adapter, $path);
+        try {
+            $feature = $this->changelog($adapter, $path);
+        } catch (InvalidXmlException $exception) {
+            return $this->warnAboutInvalidXml($exception);
+        }
 
         $change = new Change(
             $this->getTypeArgument(),

--- a/src/Commands/ChangelogCurrentCommand.php
+++ b/src/Commands/ChangelogCurrentCommand.php
@@ -4,10 +4,14 @@ namespace MarkWalet\Changelog\Commands;
 
 use Illuminate\Console\Command;
 use MarkWalet\Changelog\Adapters\FeatureAdapter;
+use MarkWalet\Changelog\Commands\Concerns\WarnsAboutInvalidXml;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\GitState\Drivers\GitDriver;
 
 class ChangelogCurrentCommand extends Command
 {
+    use WarnsAboutInvalidXml;
+
     /**
      * The name and signature of the console command.
      *
@@ -39,7 +43,12 @@ class ChangelogCurrentCommand extends Command
             return self::FAILURE;
         }
 
-        $feature = $adapter->read($path);
+        try {
+            $feature = $adapter->read($path);
+        } catch (InvalidXmlException $exception) {
+            return $this->warnAboutInvalidXml($exception);
+        }
+
         $this->line("Changes for $branch:");
 
         foreach ($feature->changes() as $change) {

--- a/src/Commands/ChangelogGenerateCommand.php
+++ b/src/Commands/ChangelogGenerateCommand.php
@@ -6,11 +6,15 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use MarkWalet\Changelog\Adapters\ReleaseAdapter;
 use MarkWalet\Changelog\ChangelogFormatterFactory;
+use MarkWalet\Changelog\Commands\Concerns\WarnsAboutInvalidXml;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Release;
 use Throwable;
 
 class ChangelogGenerateCommand extends Command
 {
+    use WarnsAboutInvalidXml;
+
     /**
      * The name and signature of the console command.
      *
@@ -38,7 +42,11 @@ class ChangelogGenerateCommand extends Command
         $readPath = $this->readPath();
         $writePath = $this->writePath();
 
-        $releases = $this->releases($adapter, $readPath);
+        try {
+            $releases = $this->releases($adapter, $readPath);
+        } catch (InvalidXmlException $exception) {
+            return $this->warnAboutInvalidXml($exception);
+        }
 
         $formatted = $formatter->multiple($releases);
         $content = $this->view($formatted);

--- a/src/Commands/ChangelogListCommand.php
+++ b/src/Commands/ChangelogListCommand.php
@@ -5,10 +5,14 @@ namespace MarkWalet\Changelog\Commands;
 use Illuminate\Console\Command;
 use MarkWalet\Changelog\Adapters\ReleaseAdapter;
 use MarkWalet\Changelog\ChangelogFormatterFactory;
+use MarkWalet\Changelog\Commands\Concerns\WarnsAboutInvalidXml;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Release;
 
 class ChangelogListCommand extends Command
 {
+    use WarnsAboutInvalidXml;
+
     /**
      * The name and signature of the console command.
      *
@@ -34,7 +38,11 @@ class ChangelogListCommand extends Command
         $formatter = $factory->make('text');
         $path = config('changelog.path');
 
-        $releases = $this->releases($adapter, $path);
+        try {
+            $releases = $this->releases($adapter, $path);
+        } catch (InvalidXmlException $exception) {
+            return $this->warnAboutInvalidXml($exception);
+        }
 
         $lines = explode(PHP_EOL, $formatter->multiple($releases));
 

--- a/src/Commands/ChangelogUnreleasedCommand.php
+++ b/src/Commands/ChangelogUnreleasedCommand.php
@@ -5,10 +5,14 @@ namespace MarkWalet\Changelog\Commands;
 use Illuminate\Console\Command;
 use MarkWalet\Changelog\Adapters\ReleaseAdapter;
 use MarkWalet\Changelog\ChangelogFormatterFactory;
+use MarkWalet\Changelog\Commands\Concerns\WarnsAboutInvalidXml;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Release;
 
 class ChangelogUnreleasedCommand extends Command
 {
+    use WarnsAboutInvalidXml;
+
     /**
      * The name and signature of the console command.
      *
@@ -34,7 +38,11 @@ class ChangelogUnreleasedCommand extends Command
         $formatter = $factory->make('text');
         $path = config('changelog.path');
 
-        $release = $this->release($adapter, $path);
+        try {
+            $release = $this->release($adapter, $path);
+        } catch (InvalidXmlException $exception) {
+            return $this->warnAboutInvalidXml($exception);
+        }
 
         $lines = explode(PHP_EOL, $formatter->single($release));
 

--- a/src/Commands/Concerns/WarnsAboutInvalidXml.php
+++ b/src/Commands/Concerns/WarnsAboutInvalidXml.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MarkWalet\Changelog\Commands\Concerns;
+
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
+
+trait WarnsAboutInvalidXml
+{
+    private function warnAboutInvalidXml(InvalidXmlException $exception): int
+    {
+        $this->warn($exception->getMessage());
+
+        return self::FAILURE;
+    }
+}

--- a/tests/Adapters/XmlFeatureAdapterTest.php
+++ b/tests/Adapters/XmlFeatureAdapterTest.php
@@ -76,4 +76,15 @@ class XmlFeatureAdapterTest extends LaravelTestCase
 
         $adapter->read($path);
     }
+
+    #[Test]
+    public function it_throws_an_exception_when_the_xml_cannot_be_parsed(): void
+    {
+        $adapter = $this->adapter();
+        $path = __DIR__.'/../test-data/invalid-syntax.xml';
+
+        $this->expectException(InvalidXmlException::class);
+
+        $adapter->read($path);
+    }
 }

--- a/tests/Commands/ChangelogAddCommandTest.php
+++ b/tests/Commands/ChangelogAddCommandTest.php
@@ -5,10 +5,12 @@ namespace MarkWalet\Changelog\Tests\Commands;
 use MarkWalet\Changelog\Adapters\FakeFeatureAdapter;
 use MarkWalet\Changelog\Adapters\FeatureAdapter;
 use MarkWalet\Changelog\Change;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Feature;
 use MarkWalet\Changelog\Tests\LaravelTestCase;
 use MarkWalet\GitState\Drivers\FakeGitDriver;
 use MarkWalet\GitState\Drivers\GitDriver;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 
 class ChangelogAddCommandTest extends LaravelTestCase
@@ -119,5 +121,22 @@ class ChangelogAddCommandTest extends LaravelTestCase
         $this->assertEquals('Removed an old feature.', $changes[1]->message());
         $this->assertEquals('changed', $changes[2]->type());
         $this->assertEquals('Changed an existing feature.', $changes[2]->message());
+    }
+
+    #[Test]
+    public function it_shows_a_warning_when_the_existing_changelog_contains_invalid_xml(): void
+    {
+        $this->app['config']['changelog.path'] = 'test-path';
+        $this->fakeBranch('test-branch');
+        $this->mock(FeatureAdapter::class, function (MockInterface $adapter) {
+            $adapter->allows('exists')->andReturn(true);
+            $adapter->allows('read')->andThrow(new InvalidXmlException('Invalid xml in "test-path/unreleased/test-branch.xml".'));
+        });
+
+        $this->artisan('changelog:add', [
+            '--type' => 'changed',
+            '--message' => 'Changed an existing feature.',
+        ])->expectsOutput('Invalid xml in "test-path/unreleased/test-branch.xml".')
+            ->assertExitCode(1);
     }
 }

--- a/tests/Commands/ChangelogCurrentCommandTest.php
+++ b/tests/Commands/ChangelogCurrentCommandTest.php
@@ -4,6 +4,7 @@ namespace MarkWalet\Changelog\Tests\Commands;
 
 use MarkWalet\Changelog\Adapters\FeatureAdapter;
 use MarkWalet\Changelog\Change;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Feature;
 use MarkWalet\Changelog\Tests\LaravelTestCase;
 use MarkWalet\GitState\Drivers\GitDriver;
@@ -58,6 +59,19 @@ class ChangelogCurrentCommandTest extends LaravelTestCase
 
         $this->artisan('changelog:current')
             ->expectsOutput('No changes found for test-branch')
+            ->assertExitCode(1);
+    }
+
+    #[Test]
+    public function it_shows_a_warning_when_the_current_changelog_contains_invalid_xml(): void
+    {
+        $this->mock(FeatureAdapter::class, function (MockInterface $adapter) {
+            $adapter->allows('exists')->andReturn(true);
+            $adapter->allows('read')->andThrow(new InvalidXmlException('Invalid xml in "fake-path/unreleased/test-branch.xml".'));
+        });
+
+        $this->artisan('changelog:current')
+            ->expectsOutput('Invalid xml in "fake-path/unreleased/test-branch.xml".')
             ->assertExitCode(1);
     }
 }

--- a/tests/Commands/ChangelogGenerateCommandTest.php
+++ b/tests/Commands/ChangelogGenerateCommandTest.php
@@ -5,9 +5,11 @@ namespace MarkWalet\Changelog\Tests\Commands;
 use MarkWalet\Changelog\Adapters\FakeReleaseAdapter;
 use MarkWalet\Changelog\Adapters\ReleaseAdapter;
 use MarkWalet\Changelog\Change;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Feature;
 use MarkWalet\Changelog\Release;
 use MarkWalet\Changelog\Tests\LaravelTestCase;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 
 class ChangelogGenerateCommandTest extends LaravelTestCase
@@ -80,6 +82,23 @@ class ChangelogGenerateCommandTest extends LaravelTestCase
             '--dry-run' => true,
             '--path' => $path,
         ])->assertExitCode(0);
+
+        $this->assertFalse(file_exists($path));
+    }
+
+    #[Test]
+    public function it_shows_a_warning_when_a_release_contains_invalid_xml(): void
+    {
+        $path = __DIR__.'/../test-data/CHANGELOG-CUSTOM.md';
+        $this->app['config']['changelog.path'] = 'fake-folder';
+        $this->mock(ReleaseAdapter::class, function (MockInterface $adapter) {
+            $adapter->allows('all')->andThrow(new InvalidXmlException('Invalid xml in "fake-folder/unreleased/example.xml".'));
+        });
+
+        $this->artisan('changelog:generate', [
+            '--path' => $path,
+        ])->expectsOutput('Invalid xml in "fake-folder/unreleased/example.xml".')
+            ->assertExitCode(1);
 
         $this->assertFalse(file_exists($path));
     }

--- a/tests/Commands/ChangelogListCommandTest.php
+++ b/tests/Commands/ChangelogListCommandTest.php
@@ -5,9 +5,11 @@ namespace MarkWalet\Changelog\Tests\Commands;
 use MarkWalet\Changelog\Adapters\FakeReleaseAdapter;
 use MarkWalet\Changelog\Adapters\ReleaseAdapter;
 use MarkWalet\Changelog\Change;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Feature;
 use MarkWalet\Changelog\Release;
 use MarkWalet\Changelog\Tests\LaravelTestCase;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 
 class ChangelogListCommandTest extends LaravelTestCase
@@ -54,5 +56,18 @@ class ChangelogListCommandTest extends LaravelTestCase
             ->expectsOutput('  - Added: Added helper commands.')
             ->expectsOutput('  - Removed: Removed unused trait.')
             ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_shows_a_warning_when_a_release_contains_invalid_xml(): void
+    {
+        $this->app['config']['changelog.path'] = 'fake-folder';
+        $this->mock(ReleaseAdapter::class, function (MockInterface $adapter) {
+            $adapter->allows('all')->andThrow(new InvalidXmlException('Invalid xml in "fake-folder/unreleased/example.xml".'));
+        });
+
+        $this->artisan('changelog:list')
+            ->expectsOutput('Invalid xml in "fake-folder/unreleased/example.xml".')
+            ->assertExitCode(1);
     }
 }

--- a/tests/Commands/ChangelogUnreleasedCommandTest.php
+++ b/tests/Commands/ChangelogUnreleasedCommandTest.php
@@ -5,9 +5,11 @@ namespace MarkWalet\Changelog\Tests\Commands;
 use MarkWalet\Changelog\Adapters\FakeReleaseAdapter;
 use MarkWalet\Changelog\Adapters\ReleaseAdapter;
 use MarkWalet\Changelog\Change;
+use MarkWalet\Changelog\Exceptions\InvalidXmlException;
 use MarkWalet\Changelog\Feature;
 use MarkWalet\Changelog\Release;
 use MarkWalet\Changelog\Tests\LaravelTestCase;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;
 
 class ChangelogUnreleasedCommandTest extends LaravelTestCase
@@ -51,5 +53,19 @@ class ChangelogUnreleasedCommandTest extends LaravelTestCase
             ->expectsOutput('  - Added: Added a new feature.')
             ->expectsOutput('  - Removed: Removed unused trait.')
             ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_shows_a_warning_when_the_unreleased_changelog_contains_invalid_xml(): void
+    {
+        config()->set('changelog.path', 'fake-folder');
+        $this->mock(ReleaseAdapter::class, function (MockInterface $adapter) {
+            $adapter->allows('exists')->andReturn(true);
+            $adapter->allows('read')->andThrow(new InvalidXmlException('Invalid xml in "fake-folder/unreleased/example.xml".'));
+        });
+
+        $this->artisan('changelog:unreleased')
+            ->expectsOutput('Invalid xml in "fake-folder/unreleased/example.xml".')
+            ->assertExitCode(1);
     }
 }

--- a/tests/test-data/invalid-syntax.xml
+++ b/tests/test-data/invalid-syntax.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feature>
+    <change type="added">Added a new feature.</change>
+    <change type="changed">Changed something that breaks the application.</feature>


### PR DESCRIPTION
## Summary
- catch malformed XML parser errors in the XML feature adapter and include the file path in the exception message
- warn instead of crashing in changelog commands that read XML files
- add regression tests and update the unreleased changelog entry

## Why
Invalid XML currently causes commands to throw an exception directly. This change turns that failure into a user-facing warning while keeping the command failure explicit.

Closes #18